### PR TITLE
Added possiblity to map PS Button, Touchpad Button and Mic Button

### DIFF
--- a/src/ControllerIO/Dualsense/dualsense.cpp
+++ b/src/ControllerIO/Dualsense/dualsense.cpp
@@ -8,8 +8,8 @@ constexpr DWORD TITLE_SIZE = 1024;
 int emulator{};
 extern bool gameProfileSet;
 
-#define isSelectPressed (buttonMapping[11])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & (((((x360Controller.inputBuffer[35 + x360Controller.bluetooth]) & 0x0F) << 8) | ((x360Controller.inputBuffer[34 + x360Controller.bluetooth]))) < 800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 4))
-#define isStartPressed (buttonMapping[11])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & (((((x360Controller.inputBuffer[35 + x360Controller.bluetooth]) & 0x0F) << 8) | ((x360Controller.inputBuffer[34 + x360Controller.bluetooth]))) >= (800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 5)))
+#define isSelectPressed (buttonMapping[14])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & ((((x360Controller.inputBuffer[35 + x360Controller.bluetooth] & 0x0F) << 8) | (x360Controller.inputBuffer[34 + x360Controller.bluetooth])) <  800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 4))
+#define isStartPressed  (buttonMapping[14])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & ((((x360Controller.inputBuffer[35 + x360Controller.bluetooth] & 0x0F) << 8) | (x360Controller.inputBuffer[34 + x360Controller.bluetooth])) >= 800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 5))
 
 extern "C" int returnSmaller(int x); //Assembly Function in src/Assembly Functions/assemblyFunctions.s
 
@@ -101,85 +101,83 @@ void inline static setButtons(controller& x360Controller) {
 	// Normal Order
 	x360Controller.ControllerState.Gamepad.wButtons = (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 4)) ? XINPUT_GAMEPAD_X : 0; //Square
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 5)) ? XINPUT_GAMEPAD_A : 0; //Cross
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 5)) ? XINPUT_GAMEPAD_A : 0; //Cross
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 6)) ? XINPUT_GAMEPAD_B : 0; //Circle
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 6)) ? XINPUT_GAMEPAD_B : 0; //Circle
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 7)) ? XINPUT_GAMEPAD_Y : 0; //Triangle
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 7)) ? XINPUT_GAMEPAD_Y : 0; //Triangle
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 0)) ? XINPUT_GAMEPAD_LEFT_SHOULDER : 0; //Left Shoulder
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 0)) ? XINPUT_GAMEPAD_LEFT_SHOULDER : 0; //Left Shoulder
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 1)) ? XINPUT_GAMEPAD_RIGHT_SHOULDER : 0; //Right Shoulder
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 1)) ? XINPUT_GAMEPAD_RIGHT_SHOULDER : 0; //Right Shoulder
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 4)) ? XINPUT_GAMEPAD_BACK : 0; //Select
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 4)) ? XINPUT_GAMEPAD_BACK : 0; //Select
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 5)) ? XINPUT_GAMEPAD_START : 0; //Start
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 5)) ? XINPUT_GAMEPAD_START : 0; //Start
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 6)) ? XINPUT_GAMEPAD_LEFT_THUMB : 0; //Left Thumb
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 6)) ? XINPUT_GAMEPAD_LEFT_THUMB : 0; //Left Thumb
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 7)) ? XINPUT_GAMEPAD_RIGHT_THUMB : 0; //Right thumb
-	
-//ControllerState.Gamepad.wButtons += joystick.rgbButtons[12] ? 0x0400 : 0; //Sony Button
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 7)) ? XINPUT_GAMEPAD_RIGHT_THUMB : 0; //Right thumb
 
 	switch ((int)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & 0x0f)) {
-	case 0: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_UP; break;
+	case 0: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_UP; break;
 
-	case 1: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_RIGHT; break;
+	case 1: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_RIGHT; break;
 
-	case 2: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_RIGHT; break;
+	case 2: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_RIGHT; break;
 
-	case 3: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_RIGHT; break;
+	case 3: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_RIGHT; break;
 
-	case 4: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_DOWN; break;
+	case 4: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_DOWN; break;
 
-	case 5: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_LEFT; break;
+	case 5: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_LEFT; break;
 
-	case 6: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_LEFT; break;
+	case 6: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_LEFT; break;
 
-	case 7: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_LEFT; break;
+	case 7: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_LEFT; break;
 	}
 }
 
 void inline static setButtonsGameProfile(controller& x360Controller) {
 
-	extern int buttonMapping[15];
+	extern int buttonMapping[19];
 
 	// Normal Order
 	x360Controller.ControllerState.Gamepad.wButtons = (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 4)) ? buttonMapping[0] : 0; //Square
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 5)) ? buttonMapping[1] : 0; //Cross
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 5)) ? buttonMapping[1] : 0; //Cross
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 6)) ? buttonMapping[2] : 0; //Circle
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 6)) ? buttonMapping[2] : 0; //Circle
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 7)) ? buttonMapping[3] : 0; //Triangle
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 7)) ? buttonMapping[3] : 0; //Triangle
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 0)) ? buttonMapping[4] : 0; //Left Shoulder
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 0)) ? buttonMapping[4] : 0; //Left Shoulder
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 1)) ? buttonMapping[5] : 0; //Right Shoulder
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 1)) ? buttonMapping[5] : 0; //Right Shoulder
 
-	//x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 4)) ? buttonMapping[6] : 0; //Select
+	x360Controller.ControllerState.Gamepad.wButtons |= isSelectPressed ? buttonMapping[6] : 0;
 
-	//x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 5)) ? buttonMapping[7] : 0; //Start
+	x360Controller.ControllerState.Gamepad.wButtons |= isStartPressed ? buttonMapping[7] : 0;
 
-	x360Controller.ControllerState.Gamepad.wButtons += isSelectPressed ? buttonMapping[6] : 0;
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 6)) ? buttonMapping[8] : 0; //Left Thumb
 
-	x360Controller.ControllerState.Gamepad.wButtons += isStartPressed ? buttonMapping[7] : 0;
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 7)) ? buttonMapping[9] : 0; //Right thumb
 
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 0)) ? buttonMapping[10] : 0; //PS Button
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 6)) ? buttonMapping[8] : 0; //Left Thumb
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 1)) ? buttonMapping[11] : 0; //Touchpad Button
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 7)) ? buttonMapping[9] : 0; //Right thumb
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 2)) ? buttonMapping[12] : 0; //Mic Button
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 4)) ? buttonMapping[11] : 0; //Left Function
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 4)) ? buttonMapping[15] : 0; //Left Function
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 5)) ? buttonMapping[12] : 0; //Right Function
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 5)) ? buttonMapping[16] : 0; //Right Function
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 6)) ? buttonMapping[13] : 0; //Left Paddle
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 6)) ? buttonMapping[17] : 0; //Left Paddle
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 7)) ? buttonMapping[14] : 0; //Right Paddle
-	//ControllerState.Gamepad.wButtons += joystick.rgbButtons[12] ? 0x0400 : 0; //Sony Button
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 7)) ? buttonMapping[18] : 0; //Right Paddle
 
-	if (buttonMapping[10] == 1) {
+	if (buttonMapping[13] == 1) {
 
 		switch ((int)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & 0x0f)) {
 
@@ -205,19 +203,19 @@ void inline static setButtonsGameProfile(controller& x360Controller) {
 	switch ((int)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & 0x0f)) {
 	case 0: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_UP; break;
 
-	case 1: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_RIGHT; break;
+	case 1: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_RIGHT; break;
 
-	case 2: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_RIGHT; break;
+	case 2: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_RIGHT; break;
 
-	case 3: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_RIGHT; break;
+	case 3: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_RIGHT; break;
 
-	case 4: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_DOWN; break;
+	case 4: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_DOWN; break;
 
-	case 5: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_LEFT; break;
+	case 5: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_LEFT; break;
 
-	case 6: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_LEFT; break;
+	case 6: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_LEFT; break;
 
-	case 7: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_LEFT; break;
+	case 7: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_LEFT; break;
 	}
 
 }

--- a/src/ControllerIO/Dualsense/dualsense.cpp
+++ b/src/ControllerIO/Dualsense/dualsense.cpp
@@ -8,8 +8,8 @@ constexpr DWORD TITLE_SIZE = 1024;
 int emulator{};
 extern bool gameProfileSet;
 
-#define isSelectPressed (buttonMapping[14])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & ((((x360Controller.inputBuffer[35 + x360Controller.bluetooth] & 0x0F) << 8) | (x360Controller.inputBuffer[34 + x360Controller.bluetooth])) <  800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 4))
-#define isStartPressed  (buttonMapping[14])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & ((((x360Controller.inputBuffer[35 + x360Controller.bluetooth] & 0x0F) << 8) | (x360Controller.inputBuffer[34 + x360Controller.bluetooth])) >= 800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 5))
+#define isSelectPressed (buttonMapping[11])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & ((((x360Controller.inputBuffer[35 + x360Controller.bluetooth] & 0x0F) << 8) | (x360Controller.inputBuffer[34 + x360Controller.bluetooth])) <  800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 4))
+#define isStartPressed  (buttonMapping[11])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & ((((x360Controller.inputBuffer[35 + x360Controller.bluetooth] & 0x0F) << 8) | (x360Controller.inputBuffer[34 + x360Controller.bluetooth])) >= 800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 5))
 
 extern "C" int returnSmaller(int x); //Assembly Function in src/Assembly Functions/assemblyFunctions.s
 
@@ -163,11 +163,11 @@ void inline static setButtonsGameProfile(controller& x360Controller) {
 
 	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 7)) ? buttonMapping[9] : 0; //Right thumb
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 0)) ? buttonMapping[10] : 0; //PS Button
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 1)) ? buttonMapping[12] : 0; //Touchpad Button
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 1)) ? buttonMapping[11] : 0; //Touchpad Button
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 0)) ? buttonMapping[13] : 0; //PS Button
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 2)) ? buttonMapping[12] : 0; //Mic Button
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 2)) ? buttonMapping[14] : 0; //Mic Button
 
 	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 4)) ? buttonMapping[15] : 0; //Left Function
 
@@ -177,7 +177,7 @@ void inline static setButtonsGameProfile(controller& x360Controller) {
 
 	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 7)) ? buttonMapping[18] : 0; //Right Paddle
 
-	if (buttonMapping[13] == 1) {
+	if (buttonMapping[10] == 1) {
 
 		switch ((int)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & 0x0f)) {
 

--- a/src/ControllerIO/Dualsense/dualsense.cpp
+++ b/src/ControllerIO/Dualsense/dualsense.cpp
@@ -8,8 +8,8 @@ constexpr DWORD TITLE_SIZE = 1024;
 int emulator{};
 extern bool gameProfileSet;
 
-#define isSelectPressed (buttonMapping[14])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & ((((x360Controller.inputBuffer[35 + x360Controller.bluetooth] & 0x0F) << 8) | (x360Controller.inputBuffer[34 + x360Controller.bluetooth])) <  800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 4))
-#define isStartPressed  (buttonMapping[14])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & ((((x360Controller.inputBuffer[35 + x360Controller.bluetooth] & 0x0F) << 8) | (x360Controller.inputBuffer[34 + x360Controller.bluetooth])) >= 800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 5))
+#define isSelectPressed (buttonMapping[13])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & ((((x360Controller.inputBuffer[35 + x360Controller.bluetooth] & 0x0F) << 8) | (x360Controller.inputBuffer[34 + x360Controller.bluetooth])) <  800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 4))
+#define isStartPressed  (buttonMapping[13])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & ((((x360Controller.inputBuffer[35 + x360Controller.bluetooth] & 0x0F) << 8) | (x360Controller.inputBuffer[34 + x360Controller.bluetooth])) >= 800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 5))
 
 extern "C" int returnSmaller(int x); //Assembly Function in src/Assembly Functions/assemblyFunctions.s
 
@@ -140,7 +140,7 @@ void inline static setButtons(controller& x360Controller) {
 
 void inline static setButtonsGameProfile(controller& x360Controller) {
 
-	extern int buttonMapping[19];
+	extern int buttonMapping[18];
 
 	// Normal Order
 	x360Controller.ControllerState.Gamepad.wButtons = (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 4)) ? buttonMapping[0] : 0; //Square
@@ -165,17 +165,15 @@ void inline static setButtonsGameProfile(controller& x360Controller) {
 
 	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 0)) ? buttonMapping[10] : 0; //PS Button
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 1)) ? buttonMapping[11] : 0; //Touchpad Button
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 2)) ? buttonMapping[11] : 0; //Mic Button
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 2)) ? buttonMapping[12] : 0; //Mic Button
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 4)) ? buttonMapping[14] : 0; //Left Function
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 4)) ? buttonMapping[15] : 0; //Left Function
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 5)) ? buttonMapping[15] : 0; //Right Function
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 5)) ? buttonMapping[16] : 0; //Right Function
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 6)) ? buttonMapping[16] : 0; //Left Paddle
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 6)) ? buttonMapping[17] : 0; //Left Paddle
-
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 7)) ? buttonMapping[18] : 0; //Right Paddle
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 7)) ? buttonMapping[17] : 0; //Right Paddle
 
 	if (buttonMapping[13] == 1) {
 

--- a/src/ControllerIO/Dualsense/dualsense.cpp
+++ b/src/ControllerIO/Dualsense/dualsense.cpp
@@ -8,8 +8,8 @@ constexpr DWORD TITLE_SIZE = 1024;
 int emulator{};
 extern bool gameProfileSet;
 
-#define isSelectPressed (buttonMapping[13])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & ((((x360Controller.inputBuffer[35 + x360Controller.bluetooth] & 0x0F) << 8) | (x360Controller.inputBuffer[34 + x360Controller.bluetooth])) <  800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 4))
-#define isStartPressed  (buttonMapping[13])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & ((((x360Controller.inputBuffer[35 + x360Controller.bluetooth] & 0x0F) << 8) | (x360Controller.inputBuffer[34 + x360Controller.bluetooth])) >= 800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 5))
+#define isSelectPressed (buttonMapping[14])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & ((((x360Controller.inputBuffer[35 + x360Controller.bluetooth] & 0x0F) << 8) | (x360Controller.inputBuffer[34 + x360Controller.bluetooth])) <  800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 4))
+#define isStartPressed  (buttonMapping[14])*(!(x360Controller.inputBuffer[33 + x360Controller.bluetooth] & (1 << 7)) & ((((x360Controller.inputBuffer[35 + x360Controller.bluetooth] & 0x0F) << 8) | (x360Controller.inputBuffer[34 + x360Controller.bluetooth])) >= 800)) ^ (x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 5))
 
 extern "C" int returnSmaller(int x); //Assembly Function in src/Assembly Functions/assemblyFunctions.s
 
@@ -140,7 +140,7 @@ void inline static setButtons(controller& x360Controller) {
 
 void inline static setButtonsGameProfile(controller& x360Controller) {
 
-	extern int buttonMapping[18];
+	extern int buttonMapping[19];
 
 	// Normal Order
 	x360Controller.ControllerState.Gamepad.wButtons = (bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 4)) ? buttonMapping[0] : 0; //Square
@@ -165,15 +165,17 @@ void inline static setButtonsGameProfile(controller& x360Controller) {
 
 	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 0)) ? buttonMapping[10] : 0; //PS Button
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 2)) ? buttonMapping[11] : 0; //Mic Button
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 1)) ? buttonMapping[11] : 0; //Touchpad Button
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 4)) ? buttonMapping[14] : 0; //Left Function
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 2)) ? buttonMapping[12] : 0; //Mic Button
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 5)) ? buttonMapping[15] : 0; //Right Function
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 4)) ? buttonMapping[15] : 0; //Left Function
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 6)) ? buttonMapping[16] : 0; //Left Paddle
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 5)) ? buttonMapping[16] : 0; //Right Function
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 7)) ? buttonMapping[17] : 0; //Right Paddle
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 6)) ? buttonMapping[17] : 0; //Left Paddle
+
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 7)) ? buttonMapping[18] : 0; //Right Paddle
 
 	if (buttonMapping[13] == 1) {
 

--- a/src/ControllerIO/Dualshock4/dualshock4.cpp
+++ b/src/ControllerIO/Dualshock4/dualshock4.cpp
@@ -5,8 +5,8 @@
 
 extern bool gameProfileSet;
 
-#define isSelectPressed (buttonMapping[14])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & ((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0f) << 8) | (x360Controller.inputBuffer[38- x360Controller.bluetooth * 2])) <  800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 4))
-#define isStartPressed  (buttonMapping[14])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & ((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0F) << 8) | (x360Controller.inputBuffer[38- x360Controller.bluetooth * 2])) >= 800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 5))
+#define isSelectPressed (buttonMapping[13])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & ((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0f) << 8) | (x360Controller.inputBuffer[38- x360Controller.bluetooth * 2])) <  800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 4))
+#define isStartPressed  (buttonMapping[13])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & ((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0F) << 8) | (x360Controller.inputBuffer[38- x360Controller.bluetooth * 2])) >= 800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 5))
 
 extern "C" int returnSmaller(int x); //Assembly Function in src/Assembly Functions/assemblyFunctions.s
 constexpr DWORD TITLE_SIZE = 1024;
@@ -55,7 +55,7 @@ void inline static setButtons(controller& x360Controller) {
 }
 
 void inline static setButtonsGameProfile(controller& x360Controller) {
-	extern int buttonMapping[19];
+	extern int buttonMapping[18];
 
 	// Normal Order
 	x360Controller.ControllerState.Gamepad.wButtons = (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 4)) ? buttonMapping[0] : 0; //Square
@@ -79,10 +79,6 @@ void inline static setButtonsGameProfile(controller& x360Controller) {
 	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 7)) ? buttonMapping[9] : 0; //Right thumb
 	
 	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 - x360Controller.bluetooth * 2] & (1 << 0)) ? buttonMapping[10] : 0; //PS Button
-
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 - x360Controller.bluetooth * 2] & (1 << 1)) ? buttonMapping[11] : 0; //Touchpad Button
-
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 - x360Controller.bluetooth * 2] & (1 << 2)) ? buttonMapping[12] : 0; //Mic Button
 
 	if (buttonMapping[13] == 1) {
 

--- a/src/ControllerIO/Dualshock4/dualshock4.cpp
+++ b/src/ControllerIO/Dualshock4/dualshock4.cpp
@@ -5,8 +5,8 @@
 
 extern bool gameProfileSet;
 
-#define isSelectPressed (buttonMapping[13])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & ((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0f) << 8) | (x360Controller.inputBuffer[38- x360Controller.bluetooth * 2])) <  800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 4))
-#define isStartPressed  (buttonMapping[13])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & ((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0F) << 8) | (x360Controller.inputBuffer[38- x360Controller.bluetooth * 2])) >= 800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 5))
+#define isSelectPressed (buttonMapping[14])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & ((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0f) << 8) | (x360Controller.inputBuffer[38- x360Controller.bluetooth * 2])) <  800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 4))
+#define isStartPressed  (buttonMapping[14])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & ((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0F) << 8) | (x360Controller.inputBuffer[38- x360Controller.bluetooth * 2])) >= 800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 5))
 
 extern "C" int returnSmaller(int x); //Assembly Function in src/Assembly Functions/assemblyFunctions.s
 constexpr DWORD TITLE_SIZE = 1024;
@@ -55,7 +55,7 @@ void inline static setButtons(controller& x360Controller) {
 }
 
 void inline static setButtonsGameProfile(controller& x360Controller) {
-	extern int buttonMapping[18];
+	extern int buttonMapping[19];
 
 	// Normal Order
 	x360Controller.ControllerState.Gamepad.wButtons = (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 4)) ? buttonMapping[0] : 0; //Square
@@ -79,6 +79,10 @@ void inline static setButtonsGameProfile(controller& x360Controller) {
 	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 7)) ? buttonMapping[9] : 0; //Right thumb
 	
 	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 - x360Controller.bluetooth * 2] & (1 << 0)) ? buttonMapping[10] : 0; //PS Button
+
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 - x360Controller.bluetooth * 2] & (1 << 1)) ? buttonMapping[11] : 0; //Touchpad Button
+
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 - x360Controller.bluetooth * 2] & (1 << 2)) ? buttonMapping[12] : 0; //Mic Button
 
 	if (buttonMapping[13] == 1) {
 

--- a/src/ControllerIO/Dualshock4/dualshock4.cpp
+++ b/src/ControllerIO/Dualshock4/dualshock4.cpp
@@ -5,8 +5,8 @@
 
 extern bool gameProfileSet;
 
-#define isSelectPressed (buttonMapping[14])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & ((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0f) << 8) | (x360Controller.inputBuffer[38- x360Controller.bluetooth * 2])) <  800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 4))
-#define isStartPressed  (buttonMapping[14])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & ((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0F) << 8) | (x360Controller.inputBuffer[38- x360Controller.bluetooth * 2])) >= 800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 5))
+#define isSelectPressed (buttonMapping[11])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & ((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0f) << 8) | (x360Controller.inputBuffer[38- x360Controller.bluetooth * 2])) <  800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 4))
+#define isStartPressed  (buttonMapping[11])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & ((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0F) << 8) | (x360Controller.inputBuffer[38- x360Controller.bluetooth * 2])) >= 800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 5))
 
 extern "C" int returnSmaller(int x); //Assembly Function in src/Assembly Functions/assemblyFunctions.s
 constexpr DWORD TITLE_SIZE = 1024;
@@ -78,13 +78,11 @@ void inline static setButtonsGameProfile(controller& x360Controller) {
 
 	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 7)) ? buttonMapping[9] : 0; //Right thumb
 	
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 - x360Controller.bluetooth * 2] & (1 << 0)) ? buttonMapping[10] : 0; //PS Button
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 - x360Controller.bluetooth * 2] & (1 << 1)) ? buttonMapping[12] : 0; //Touchpad Button
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 - x360Controller.bluetooth * 2] & (1 << 1)) ? buttonMapping[11] : 0; //Touchpad Button
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 - x360Controller.bluetooth * 2] & (1 << 0)) ? buttonMapping[13] : 0; //PS Button
 
-	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 - x360Controller.bluetooth * 2] & (1 << 2)) ? buttonMapping[12] : 0; //Mic Button
-
-	if (buttonMapping[13] == 1) {
+	if (buttonMapping[10] == 1) {
 
 		switch ((int)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & 0x0f)) {
 

--- a/src/ControllerIO/Dualshock4/dualshock4.cpp
+++ b/src/ControllerIO/Dualshock4/dualshock4.cpp
@@ -5,8 +5,8 @@
 
 extern bool gameProfileSet;
 
-#define isSelectPressed (buttonMapping[11])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & (((((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0f) << 8) | x360Controller.inputBuffer[38- x360Controller.bluetooth * 2]))) < 800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 4)))
-#define isStartPressed (buttonMapping[11])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & (((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2]) & 0x0F) << 8) | ((x360Controller.inputBuffer[38- x360Controller.bluetooth * 2]))) >= (800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 5)))
+#define isSelectPressed (buttonMapping[14])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & ((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0f) << 8) | (x360Controller.inputBuffer[38- x360Controller.bluetooth * 2])) <  800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 4))
+#define isStartPressed  (buttonMapping[14])*(!(x360Controller.inputBuffer[37- x360Controller.bluetooth * 2] & (1 << 7)) & ((((x360Controller.inputBuffer[39- x360Controller.bluetooth * 2] & 0x0F) << 8) | (x360Controller.inputBuffer[38- x360Controller.bluetooth * 2])) >= 800)) ^ (x360Controller.inputBuffer[8- x360Controller.bluetooth * 2] & (1 << 5))
 
 extern "C" int returnSmaller(int x); //Assembly Function in src/Assembly Functions/assemblyFunctions.s
 constexpr DWORD TITLE_SIZE = 1024;
@@ -15,72 +15,76 @@ void inline static setButtons(controller& x360Controller) {
 	// Normal Order
 	x360Controller.ControllerState.Gamepad.wButtons = (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 4)) ? XINPUT_GAMEPAD_X : 0; //Square
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 5)) ? XINPUT_GAMEPAD_A : 0; //Cross
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 5)) ? XINPUT_GAMEPAD_A : 0; //Cross
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 6)) ? XINPUT_GAMEPAD_B : 0; //Circle
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 6)) ? XINPUT_GAMEPAD_B : 0; //Circle
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 7)) ? XINPUT_GAMEPAD_Y : 0; //Triangle
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 7)) ? XINPUT_GAMEPAD_Y : 0; //Triangle
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 0)) ? XINPUT_GAMEPAD_LEFT_SHOULDER : 0; //Left Shoulder
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 0)) ? XINPUT_GAMEPAD_LEFT_SHOULDER : 0; //Left Shoulder
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 1)) ? XINPUT_GAMEPAD_RIGHT_SHOULDER : 0; //Right Shoulder
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 1)) ? XINPUT_GAMEPAD_RIGHT_SHOULDER : 0; //Right Shoulder
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 4)) ? XINPUT_GAMEPAD_BACK : 0; //Select
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 4)) ? XINPUT_GAMEPAD_BACK : 0; //Select
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 5)) ? XINPUT_GAMEPAD_START : 0; //Start
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 5)) ? XINPUT_GAMEPAD_START : 0; //Start
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 6)) ? XINPUT_GAMEPAD_LEFT_THUMB : 0; //Left Thumb
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 6)) ? XINPUT_GAMEPAD_LEFT_THUMB : 0; //Left Thumb
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 7)) ? XINPUT_GAMEPAD_RIGHT_THUMB : 0; //Right thumb
-	//ControllerState.Gamepad.wButtons += joystick.rgbButtons[12] ? 0x0400 : 0; //Sony Button
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 7)) ? XINPUT_GAMEPAD_RIGHT_THUMB : 0; //Right thumb
 
 	switch ((int)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & 0x0F)) {
-	case 0: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_UP; break;
+	case 0: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_UP; break;
 
-	case 1: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_RIGHT; break;
+	case 1: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_RIGHT; break;
 
-	case 2: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_RIGHT; break;
+	case 2: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_RIGHT; break;
 
-	case 3: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_RIGHT; break;
+	case 3: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_RIGHT; break;
 
-	case 4: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_DOWN; break;
+	case 4: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_DOWN; break;
 
-	case 5: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_LEFT; break;
+	case 5: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_LEFT; break;
 
-	case 6: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_LEFT; break;
+	case 6: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_LEFT; break;
 
-	case 7: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_LEFT; break;
+	case 7: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_LEFT; break;
 
 	}
 
 }
 
 void inline static setButtonsGameProfile(controller& x360Controller) {
-	extern int buttonMapping[15];
+	extern int buttonMapping[19];
 
 	// Normal Order
 	x360Controller.ControllerState.Gamepad.wButtons = (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 4)) ? buttonMapping[0] : 0; //Square
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 5)) ? buttonMapping[1] : 0; //Cross
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 5)) ? buttonMapping[1] : 0; //Cross
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 6)) ? buttonMapping[2] : 0; //Circle
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 6)) ? buttonMapping[2] : 0; //Circle
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 7)) ? buttonMapping[3] : 0; //Triangle
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & (1 << 7)) ? buttonMapping[3] : 0; //Triangle
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 0)) ? buttonMapping[4] : 0; //Left Shoulder
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 0)) ? buttonMapping[4] : 0; //Left Shoulder
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 1)) ? buttonMapping[5] : 0; //Right Shoulder
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 1)) ? buttonMapping[5] : 0; //Right Shoulder
 
-	x360Controller.ControllerState.Gamepad.wButtons += isSelectPressed ? buttonMapping[6] : 0;
+	x360Controller.ControllerState.Gamepad.wButtons |= isSelectPressed ? buttonMapping[6] : 0;
 
-	x360Controller.ControllerState.Gamepad.wButtons += isStartPressed ? buttonMapping[7] : 0;
+	x360Controller.ControllerState.Gamepad.wButtons |= isStartPressed ? buttonMapping[7] : 0;
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 6)) ? buttonMapping[8] : 0; //Left Thumb
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 6)) ? buttonMapping[8] : 0; //Left Thumb
 
-	x360Controller.ControllerState.Gamepad.wButtons += (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 7)) ? buttonMapping[9] : 0; //Right thumb
-	//ControllerState.Gamepad.wButtons += joystick.rgbButtons[12] ? 0x0400 : 0; //Sony Button
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[8 - x360Controller.bluetooth * 2] & (1 << 7)) ? buttonMapping[9] : 0; //Right thumb
+	
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 - x360Controller.bluetooth * 2] & (1 << 0)) ? buttonMapping[10] : 0; //PS Button
 
-	if (buttonMapping[10] == 1) {
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 - x360Controller.bluetooth * 2] & (1 << 1)) ? buttonMapping[11] : 0; //Touchpad Button
+
+	x360Controller.ControllerState.Gamepad.wButtons |= (bool)(x360Controller.inputBuffer[9 - x360Controller.bluetooth * 2] & (1 << 2)) ? buttonMapping[12] : 0; //Mic Button
+
+	if (buttonMapping[13] == 1) {
 
 		switch ((int)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & 0x0f)) {
 
@@ -104,21 +108,21 @@ void inline static setButtonsGameProfile(controller& x360Controller) {
 	}
 
 	switch ((int)(x360Controller.inputBuffer[7 - x360Controller.bluetooth * 2] & 0x0F)) {
-	case 0: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_UP; break;
+	case 0: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_UP; break;
 
-	case 1: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_RIGHT; break;
+	case 1: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_RIGHT; break;
 
-	case 2: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_RIGHT; break;
+	case 2: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_RIGHT; break;
 
-	case 3: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_RIGHT; break;
+	case 3: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_RIGHT; break;
 
-	case 4: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_DOWN; break;
+	case 4: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_DOWN; break;
 
-	case 5: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_LEFT; break;
+	case 5: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_DOWN + XINPUT_GAMEPAD_DPAD_LEFT; break;
 
-	case 6: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_LEFT; break;
+	case 6: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_LEFT; break;
 
-	case 7: x360Controller.ControllerState.Gamepad.wButtons += XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_LEFT; break;
+	case 7: x360Controller.ControllerState.Gamepad.wButtons |= XINPUT_GAMEPAD_DPAD_UP + XINPUT_GAMEPAD_DPAD_LEFT; break;
 
 	}
 }

--- a/src/Misc/util.cpp
+++ b/src/Misc/util.cpp
@@ -37,38 +37,34 @@ void debugData(controller &x360Controller) {
 		case 7: DEBUG("Dpad Up and Dpad Left"); break;
 		}
 
-		if ((bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 4))) DEBUG("Square Button\n");
+		if ((bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 4))) DEBUG("Square Button");
 
-		if ((bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 5))) DEBUG("Cross Button\n");
+		if ((bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 5))) DEBUG("Cross Button");
 
-		if ((bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 6))) DEBUG("Circle Button\n");
+		if ((bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 6))) DEBUG("Circle Button");
 
-		if ((bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 7))) DEBUG("Triangle Button\n");
+		if ((bool)(x360Controller.inputBuffer[8 + x360Controller.bluetooth] & (1 << 7))) DEBUG("Triangle Button");
 
-		if ((bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 0))) DEBUG("L1 Button\n");
+		if ((bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 0))) DEBUG("L1 Button");
 
-		if ((bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 1))) DEBUG("R1 Button\n");
+		if ((bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 1))) DEBUG("R1 Button");
 
-		if ((bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 4))) DEBUG("Select Button\n");
+		if ((bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 4))) DEBUG("Select Button");
 
-		if ((bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 5))) DEBUG("Start Button\n");
+		if ((bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 5))) DEBUG("Start Button");
 
-		if ((bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 6))) DEBUG("L3 Button\n");
+		if ((bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 6))) DEBUG("L3 Button");
 
-		if ((bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 7))) DEBUG("R3 Button\n");
+		if ((bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 7))) DEBUG("R3 Button");
 
-		if ((bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 0))) DEBUG("Sony/Home Button\n");
+		if ((bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 0))) DEBUG("PS Button");
 
-		if ((bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & 0x02)) DEBUG("Toutchpad Click\n");
+		if ((bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 1))) DEBUG("Touchpad Button");
+
+		if ((bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 2))) DEBUG("Mic Button");
 
 		if (!x360Controller.isConnected)
 			DEBUG("Failed to get device state");
-			
-		
 	}
 }
 #endif
-
-
-
-

--- a/src/Misc/util.cpp
+++ b/src/Misc/util.cpp
@@ -57,7 +57,7 @@ void debugData(controller &x360Controller) {
 
 		if ((bool)(x360Controller.inputBuffer[9 + x360Controller.bluetooth] & (1 << 7))) DEBUG("R3 Button");
 
-		if ((bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 0))) DEBUG("PS Button");
+		if ((bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 0))) DEBUG("Sony/Home Button");
 
 		if ((bool)(x360Controller.inputBuffer[10 + x360Controller.bluetooth] & (1 << 1))) DEBUG("Touchpad Button");
 

--- a/src/User Settings/Button Mappings/button Mappings.cpp
+++ b/src/User Settings/Button Mappings/button Mappings.cpp
@@ -1,31 +1,47 @@
 #include "button Mappings.h"
 #include <map>
 
-static std::map<int, const char*> buttons = {
-		{0x4000,"Square"},
-		{0x1000,"Cross"},
-		{0x2000,"Circle"},
-		{0x8000,"Triangle"},
-		{0x0100,"Left Shoulder"},
-		{0x0200,"Right Shoulder"},
-		{0x0020,"Select"},
-		{0x0010,"Start"},
-		{0x0040,"Left Thumb"},
-		{0x0080,"Right Thumb"},
+static std::map<int, const char*> xboxButtons = {
+	{0x0000,"None"},
+	{0x4000,"X"},
+	{0x1000,"A"},
+	{0x2000,"B"},
+	{0x8000,"Y"},
+	{0x0100,"LB"},
+	{0x0200,"RB"},
+	{0x0020,"Back"},
+	{0x0010,"Start"},
+	{0x0040,"LSB"},
+	{0x0080,"RSB"},
 };
 
-static std::string dualsenseEdgeExtras[4]{
-	"Left Function",
-	"Right Function",
-	"Left Paddle",
-	"Right Paddle"
+static const char* dualsenseEdgeExtras[4]{
+	"L Fn    ",
+	"R Fn    ",
+	"L Back  ",
+	"R Back  ",
 };
 
+static const char* psButtons[13]{
+	"Square  ",
+	"Cross   ",
+	"Circle  ",
+	"Triangle",
+	"L1      ",
+	"R1      ",
+	"Share   ",
+	"Options ",
+	"L3      ",
+	"R3      ",
+	"PS      ",
+	"Touchpad",
+	"Mic     ",
+};
 
-static const int buttonsKeys[10]{ 0x4000,0x1000,0x2000,0x8000,0x0100,0x0200,0x0020,0x0010,0x0040,0x0080 };
+static const int xboxButtonsKeys[11]{ 0x0000,0x4000,0x1000,0x2000,0x8000,0x0100,0x0200,0x0020,0x0010,0x0040,0x0080 };
 
 void buttonMappingEditor(bool& makerOpen, int* buttonProfile) {
-	extern int buttonMapping[15];
+	extern int buttonMapping[19];
 	extern bool gameProfileSet;
 
 	for (int i = 0; i < IM_ARRAYSIZE(buttonMapping); i++) buttonMapping[i] = buttonProfile[i];
@@ -33,32 +49,33 @@ void buttonMappingEditor(bool& makerOpen, int* buttonProfile) {
 
 	if (ImGui::Begin("Button Remapper", &makerOpen)) {
 
-		for (short int i = 0; i < IM_ARRAYSIZE(buttonsKeys); i++) {
+		for (short int i = 0; i < IM_ARRAYSIZE(psButtons); i++) {
 			ImGui::PushID(&buttonProfile[i]);
-			ImGui::Text(buttons[buttonsKeys[i]]);
+			ImGui::Text(psButtons[i]);
 			ImGui::SameLine();
-			if (ImGui::BeginCombo("##Change Button", std::format("{}", buttons[buttonProfile[i]]).c_str())) {
-				for (short int j = 0; j < IM_ARRAYSIZE(buttonsKeys); j++) if (ImGui::Selectable(buttons[buttonsKeys[j]])) buttonProfile[i] = buttonsKeys[j];
+			if (ImGui::BeginCombo("##Change Button", xboxButtons[buttonProfile[i]])) {
+				for (short int j = 0; j < IM_ARRAYSIZE(xboxButtonsKeys); j++) if (ImGui::Selectable(xboxButtons[xboxButtonsKeys[j]])) buttonProfile[i] = xboxButtonsKeys[j];
 				ImGui::EndCombo();
 			}
 			ImGui::PopID();
 		}
 
 		for (short int i = 0; i < IM_ARRAYSIZE(dualsenseEdgeExtras); i++) {
-			ImGui::PushID(&buttonProfile[i + 11]);
-			ImGui::Text(dualsenseEdgeExtras[i].c_str());
+			ImGui::PushID(&buttonProfile[i + 15]);
+			ImGui::Text(dualsenseEdgeExtras[i]);
 			ImGui::SameLine();
-			if (ImGui::BeginCombo("##Change Dualsense Extras", buttons[buttonProfile[i + 11]])) {
-				for (short int j = 0; j < IM_ARRAYSIZE(buttonsKeys); j++) if (ImGui::Selectable(buttons[buttonsKeys[j]])) buttonProfile[i + 11] = buttonsKeys[j];
+			if (ImGui::BeginCombo("##Change Dualsense Extras", xboxButtons[buttonProfile[i + 15]])) {
+				for (short int j = 0; j < IM_ARRAYSIZE(xboxButtonsKeys); j++) if (ImGui::Selectable(xboxButtons[xboxButtonsKeys[j]])) buttonProfile[i + 15] = xboxButtonsKeys[j];
 				ImGui::EndCombo();
 			}
 			ImGui::PopID();
 		}
-		if (ImGui::RadioButton("Map dpad to joysticks", buttonProfile[10]))
-			buttonProfile[10] = 1 * (buttonProfile[10] <= 0);
-		if (ImGui::RadioButton("Start/Select on Touchpad", buttonProfile[11]))
-			buttonProfile[11] = 1 * (buttonProfile[11] <= 0);
 
+		if (ImGui::RadioButton("Map D-Pad to joysticks", buttonProfile[13]))
+			buttonProfile[13] = 1 * (buttonProfile[13] <= 0);
+
+		if (ImGui::RadioButton("Start/Select on Touchpad", buttonProfile[14]))
+			buttonProfile[14] = 1 * (buttonProfile[14] <= 0);
 	}
 	ImGui::End();
 }

--- a/src/User Settings/Button Mappings/button Mappings.cpp
+++ b/src/User Settings/Button Mappings/button Mappings.cpp
@@ -1,41 +1,43 @@
 #include "button Mappings.h"
 #include <map>
 
+
 static std::map<int, const char*> xboxButtons = {
 	{0x0000,"None"},
 	{0x4000,"X"},
 	{0x1000,"A"},
 	{0x2000,"B"},
 	{0x8000,"Y"},
-	{0x0100,"LB"},
-	{0x0200,"RB"},
+	{0x0100,"Left Shoulder"},
+	{0x0200,"Right Shoulder"},
 	{0x0020,"Back"},
 	{0x0010,"Start"},
-	{0x0040,"LSB"},
-	{0x0080,"RSB"},
+	{0x0040,"Left Thumb"},
+	{0x0080,"Right Thumb"},
 };
 
-static const char* dualsenseEdgeExtras[4]{
-	"L Fn    ",
-	"R Fn    ",
-	"L Back  ",
-	"R Back  ",
+static const char* extraButtons[7]{
+	"Touchpad      ",
+	"Home          ",
+	"Mic           ",
+	"Left Function ",
+	"Right Function",
+	"Left Paddle   ",
+	"Right Paddle  ",
 };
 
-static const char* psButtons[13]{
-	"Square  ",
-	"Cross   ",
-	"Circle  ",
-	"Triangle",
-	"L1      ",
-	"R1      ",
-	"Share   ",
-	"Options ",
-	"L3      ",
-	"R3      ",
-	"PS      ",
-	"Touchpad",
-	"Mic     ",
+static const char* psButtons[10]{
+	"Square        ",
+	"Cross         ",
+	"Circle        ",
+	"Triangle      ",
+	"L1            ",
+	"R1            ",
+	"Share         ",
+	"Options       ",
+	"L3            ",
+	"R3            ",
+
 };
 
 static const int xboxButtonsKeys[11]{ 0x0000,0x4000,0x1000,0x2000,0x8000,0x0100,0x0200,0x0020,0x0010,0x0040,0x0080 };
@@ -60,22 +62,23 @@ void buttonMappingEditor(bool& makerOpen, int* buttonProfile) {
 			ImGui::PopID();
 		}
 
-		for (short int i = 0; i < IM_ARRAYSIZE(dualsenseEdgeExtras); i++) {
+		for (short int i = (bool)buttonProfile[11]; i < IM_ARRAYSIZE(extraButtons); i++) {
 			ImGui::PushID(&buttonProfile[i + 15]);
-			ImGui::Text(dualsenseEdgeExtras[i]);
+			ImGui::Text(extraButtons[i]);
 			ImGui::SameLine();
-			if (ImGui::BeginCombo("##Change Dualsense Extras", xboxButtons[buttonProfile[i + 15]])) {
-				for (short int j = 0; j < IM_ARRAYSIZE(xboxButtonsKeys); j++) if (ImGui::Selectable(xboxButtons[xboxButtonsKeys[j]])) buttonProfile[i + 15] = xboxButtonsKeys[j];
+			if (ImGui::BeginCombo("##Change Dualsense Extras", xboxButtons[buttonProfile[i + 12]])) {
+				for (short int j = 0; j < IM_ARRAYSIZE(xboxButtonsKeys); j++) if (ImGui::Selectable(xboxButtons[xboxButtonsKeys[j]])) buttonProfile[i + 12] = xboxButtonsKeys[j];
 				ImGui::EndCombo();
 			}
 			ImGui::PopID();
 		}
 
-		if (ImGui::RadioButton("Map D-Pad to joysticks", buttonProfile[13]))
-			buttonProfile[13] = 1 * (buttonProfile[13] <= 0);
+		if (ImGui::RadioButton("Map D-Pad to joysticks", buttonProfile[10]))
+			buttonProfile[10] = 1 * (buttonProfile[10] <= 0);
 
-		if (ImGui::RadioButton("Start/Select on Touchpad", buttonProfile[14]))
-			buttonProfile[14] = 1 * (buttonProfile[14] <= 0);
+		if (ImGui::RadioButton("Start/Select on Touchpad", buttonProfile[11]))
+			buttonProfile[11] = 1 * (buttonProfile[11] <= 0);
+		buttonProfile[12] = buttonProfile[12] * (buttonProfile[11] <= 0); //If Start/Select on touch is activated then the binding on the touchbutton is resetted
 	}
 	ImGui::End();
 }

--- a/src/User Settings/Button Mappings/button Mappings.cpp
+++ b/src/User Settings/Button Mappings/button Mappings.cpp
@@ -7,41 +7,40 @@ static std::map<int, const char*> xboxButtons = {
 	{0x1000,"A"},
 	{0x2000,"B"},
 	{0x8000,"Y"},
-	{0x0100,"LB"},
-	{0x0200,"RB"},
+	{0x0100,"Left Shoulder"},
+	{0x0200,"Right Shoulder"},
 	{0x0020,"Back"},
 	{0x0010,"Start"},
-	{0x0040,"LSB"},
-	{0x0080,"RSB"},
+	{0x0040,"Left Thumb"},
+	{0x0080,"Right Thumb"},
 };
 
 static const char* dualsenseEdgeExtras[4]{
-	"L Fn    ",
-	"R Fn    ",
-	"L Back  ",
-	"R Back  ",
+	"Left Function ",
+	"Right Function",
+	"Left Paddle   ",
+	"Right Paddle  ",
 };
 
-static const char* psButtons[13]{
-	"Square  ",
-	"Cross   ",
-	"Circle  ",
-	"Triangle",
-	"L1      ",
-	"R1      ",
-	"Share   ",
-	"Options ",
-	"L3      ",
-	"R3      ",
-	"PS      ",
-	"Touchpad",
-	"Mic     ",
+static const char* psButtons[12]{
+	"Square        ",
+	"Cross         ",
+	"Circle        ",
+	"Triangle      ",
+	"L1            ",
+	"R1            ",
+	"Share         ",
+	"Options       ",
+	"L3            ",
+	"R3            ",
+	"Home          ",
+	"Mic           ",
 };
 
 static const int xboxButtonsKeys[11]{ 0x0000,0x4000,0x1000,0x2000,0x8000,0x0100,0x0200,0x0020,0x0010,0x0040,0x0080 };
 
 void buttonMappingEditor(bool& makerOpen, int* buttonProfile) {
-	extern int buttonMapping[19];
+	extern int buttonMapping[18];
 	extern bool gameProfileSet;
 
 	for (int i = 0; i < IM_ARRAYSIZE(buttonMapping); i++) buttonMapping[i] = buttonProfile[i];
@@ -59,7 +58,6 @@ void buttonMappingEditor(bool& makerOpen, int* buttonProfile) {
 			}
 			ImGui::PopID();
 		}
-
 		for (short int i = 0; i < IM_ARRAYSIZE(dualsenseEdgeExtras); i++) {
 			ImGui::PushID(&buttonProfile[i + 15]);
 			ImGui::Text(dualsenseEdgeExtras[i]);

--- a/src/User Settings/Button Mappings/button Mappings.cpp
+++ b/src/User Settings/Button Mappings/button Mappings.cpp
@@ -7,40 +7,41 @@ static std::map<int, const char*> xboxButtons = {
 	{0x1000,"A"},
 	{0x2000,"B"},
 	{0x8000,"Y"},
-	{0x0100,"Left Shoulder"},
-	{0x0200,"Right Shoulder"},
+	{0x0100,"LB"},
+	{0x0200,"RB"},
 	{0x0020,"Back"},
 	{0x0010,"Start"},
-	{0x0040,"Left Thumb"},
-	{0x0080,"Right Thumb"},
+	{0x0040,"LSB"},
+	{0x0080,"RSB"},
 };
 
 static const char* dualsenseEdgeExtras[4]{
-	"Left Function ",
-	"Right Function",
-	"Left Paddle   ",
-	"Right Paddle  ",
+	"L Fn    ",
+	"R Fn    ",
+	"L Back  ",
+	"R Back  ",
 };
 
-static const char* psButtons[12]{
-	"Square        ",
-	"Cross         ",
-	"Circle        ",
-	"Triangle      ",
-	"L1            ",
-	"R1            ",
-	"Share         ",
-	"Options       ",
-	"L3            ",
-	"R3            ",
-	"Home          ",
-	"Mic           ",
+static const char* psButtons[13]{
+	"Square  ",
+	"Cross   ",
+	"Circle  ",
+	"Triangle",
+	"L1      ",
+	"R1      ",
+	"Share   ",
+	"Options ",
+	"L3      ",
+	"R3      ",
+	"PS      ",
+	"Touchpad",
+	"Mic     ",
 };
 
 static const int xboxButtonsKeys[11]{ 0x0000,0x4000,0x1000,0x2000,0x8000,0x0100,0x0200,0x0020,0x0010,0x0040,0x0080 };
 
 void buttonMappingEditor(bool& makerOpen, int* buttonProfile) {
-	extern int buttonMapping[18];
+	extern int buttonMapping[19];
 	extern bool gameProfileSet;
 
 	for (int i = 0; i < IM_ARRAYSIZE(buttonMapping); i++) buttonMapping[i] = buttonProfile[i];
@@ -58,6 +59,7 @@ void buttonMappingEditor(bool& makerOpen, int* buttonProfile) {
 			}
 			ImGui::PopID();
 		}
+
 		for (short int i = 0; i < IM_ARRAYSIZE(dualsenseEdgeExtras); i++) {
 			ImGui::PushID(&buttonProfile[i + 15]);
 			ImGui::Text(dualsenseEdgeExtras[i]);

--- a/src/User Settings/Game Profiles/gameProfile.cpp
+++ b/src/User Settings/Game Profiles/gameProfile.cpp
@@ -11,7 +11,7 @@
 extern bool gameProfileSet = false;
 extern bool profileEdit = false;
 extern UCHAR rumble[2];
-extern int buttonMapping[19]{};
+extern int buttonMapping[18]{};
 extern bool triggerMaker{ false }, profileMacroOpen{ false }, lightEditor{ false }, buttonRemapper{ false };
 
 

--- a/src/User Settings/Game Profiles/gameProfile.cpp
+++ b/src/User Settings/Game Profiles/gameProfile.cpp
@@ -11,7 +11,7 @@
 extern bool gameProfileSet = false;
 extern bool profileEdit = false;
 extern UCHAR rumble[2];
-extern int buttonMapping[15]{};
+extern int buttonMapping[19]{};
 extern bool triggerMaker{ false }, profileMacroOpen{ false }, lightEditor{ false }, buttonRemapper{ false };
 
 

--- a/src/User Settings/Game Profiles/gameProfile.cpp
+++ b/src/User Settings/Game Profiles/gameProfile.cpp
@@ -11,7 +11,7 @@
 extern bool gameProfileSet = false;
 extern bool profileEdit = false;
 extern UCHAR rumble[2];
-extern int buttonMapping[18]{};
+extern int buttonMapping[19]{};
 extern bool triggerMaker{ false }, profileMacroOpen{ false }, lightEditor{ false }, buttonRemapper{ false };
 
 

--- a/src/User Settings/Game Profiles/gameProfile.h
+++ b/src/User Settings/Game Profiles/gameProfile.h
@@ -16,7 +16,7 @@ public:
 	std::wstring appName{};
 	std::vector<Macros> gameMacros{};
 	                       // Default Values
-	int buttonMapping[19]{ XINPUT_GAMEPAD_X, // Square
+	int buttonMapping[18]{ XINPUT_GAMEPAD_X, // Square
 	                       XINPUT_GAMEPAD_A, // Cross
 	                       XINPUT_GAMEPAD_B, // Circle
 	                       XINPUT_GAMEPAD_Y, // Triangle
@@ -27,7 +27,6 @@ public:
 	                       XINPUT_GAMEPAD_LEFT_THUMB, // L3
 	                       XINPUT_GAMEPAD_RIGHT_THUMB, // R3
 	                       0, // PS Button
-	                       0, // Touchpad Button
 	                       0, // Mic Button
 	                       0, // DpadToJoystick (Bool)
 	                       0, // Start/Select on Touchpad (Bool)

--- a/src/User Settings/Game Profiles/gameProfile.h
+++ b/src/User Settings/Game Profiles/gameProfile.h
@@ -15,12 +15,27 @@ public:
 	std::string appNameLiteral{};
 	std::wstring appName{};
 	std::vector<Macros> gameMacros{};
-
-	int buttonMapping[15]{ XINPUT_GAMEPAD_X ,XINPUT_GAMEPAD_A,XINPUT_GAMEPAD_B,XINPUT_GAMEPAD_Y,
-						   XINPUT_GAMEPAD_LEFT_SHOULDER,XINPUT_GAMEPAD_RIGHT_SHOULDER,
-						   XINPUT_GAMEPAD_BACK,XINPUT_GAMEPAD_START,
-						   XINPUT_GAMEPAD_LEFT_THUMB,XINPUT_GAMEPAD_RIGHT_THUMB,
-						   0,0,0,0,0 }; //First element of this line is treated as a boolean for DpadToJoystick and the other are Dualsense Edge Extras
+	                       // Default Values
+	int buttonMapping[19]{ XINPUT_GAMEPAD_X, // Square
+	                       XINPUT_GAMEPAD_A, // Cross
+	                       XINPUT_GAMEPAD_B, // Circle
+	                       XINPUT_GAMEPAD_Y, // Triangle
+	                       XINPUT_GAMEPAD_LEFT_SHOULDER, // L1
+	                       XINPUT_GAMEPAD_RIGHT_SHOULDER, // R1
+	                       XINPUT_GAMEPAD_BACK, // Share
+	                       XINPUT_GAMEPAD_START, // Options
+	                       XINPUT_GAMEPAD_LEFT_THUMB, // L3
+	                       XINPUT_GAMEPAD_RIGHT_THUMB, // R3
+	                       0, // PS Button
+	                       0, // Touchpad Button
+	                       0, // Mic Button
+	                       0, // DpadToJoystick (Bool)
+	                       0, // Start/Select on Touchpad (Bool)
+						   0, // Edge Only : Left Function
+						   0, // Edge Only : Right Function
+						   0, // Edge Only : Left Paddle
+						   0, // Edge Only : Right Paddle
+	}; 
 
 	unsigned char gameTriggerProfile[8]{};
 	bool rumbleTriggers = 0;

--- a/src/User Settings/Game Profiles/gameProfile.h
+++ b/src/User Settings/Game Profiles/gameProfile.h
@@ -26,11 +26,11 @@ public:
 	                       XINPUT_GAMEPAD_START, // Options
 	                       XINPUT_GAMEPAD_LEFT_THUMB, // L3
 	                       XINPUT_GAMEPAD_RIGHT_THUMB, // R3
-	                       0, // PS Button
-	                       0, // Touchpad Button
-	                       0, // Mic Button
 	                       0, // DpadToJoystick (Bool)
 	                       0, // Start/Select on Touchpad (Bool)
+						   0, // Touchpad Button
+						   0, // Home/Sony Button
+						   0, // Mic Button
 						   0, // Edge Only : Left Function
 						   0, // Edge Only : Right Function
 						   0, // Edge Only : Left Paddle

--- a/src/User Settings/Game Profiles/gameProfile.h
+++ b/src/User Settings/Game Profiles/gameProfile.h
@@ -16,7 +16,7 @@ public:
 	std::wstring appName{};
 	std::vector<Macros> gameMacros{};
 	                       // Default Values
-	int buttonMapping[18]{ XINPUT_GAMEPAD_X, // Square
+	int buttonMapping[19]{ XINPUT_GAMEPAD_X, // Square
 	                       XINPUT_GAMEPAD_A, // Cross
 	                       XINPUT_GAMEPAD_B, // Circle
 	                       XINPUT_GAMEPAD_Y, // Triangle
@@ -27,6 +27,7 @@ public:
 	                       XINPUT_GAMEPAD_LEFT_THUMB, // L3
 	                       XINPUT_GAMEPAD_RIGHT_THUMB, // R3
 	                       0, // PS Button
+	                       0, // Touchpad Button
 	                       0, // Mic Button
 	                       0, // DpadToJoystick (Bool)
 	                       0, // Start/Select on Touchpad (Bool)

--- a/src/User Settings/Game Profiles/saveLoad.cpp
+++ b/src/User Settings/Game Profiles/saveLoad.cpp
@@ -135,7 +135,7 @@ void inline writeProfiles(std::string dirEntry, gameProfile& currentProfile) {
 
 	std::ifstream loadButtonMapping(std::format("{}/mapping.txt", dirEntry));
 	if (loadButtonMapping.is_open()) {
-		int buttonMappingTemp[19]{};
+		int buttonMappingTemp[18]{};
 		for (int i = 0; i < ARRAYSIZE(currentProfile.buttonMapping); i++)
 			loadButtonMapping >> buttonMappingTemp[i];
 		for (int i = 0; i < ARRAYSIZE(currentProfile.buttonMapping); i++)

--- a/src/User Settings/Game Profiles/saveLoad.cpp
+++ b/src/User Settings/Game Profiles/saveLoad.cpp
@@ -135,7 +135,7 @@ void inline writeProfiles(std::string dirEntry, gameProfile& currentProfile) {
 
 	std::ifstream loadButtonMapping(std::format("{}/mapping.txt", dirEntry));
 	if (loadButtonMapping.is_open()) {
-		int buttonMappingTemp[18]{};
+		int buttonMappingTemp[19]{};
 		for (int i = 0; i < ARRAYSIZE(currentProfile.buttonMapping); i++)
 			loadButtonMapping >> buttonMappingTemp[i];
 		for (int i = 0; i < ARRAYSIZE(currentProfile.buttonMapping); i++)

--- a/src/User Settings/Game Profiles/saveLoad.cpp
+++ b/src/User Settings/Game Profiles/saveLoad.cpp
@@ -135,7 +135,7 @@ void inline writeProfiles(std::string dirEntry, gameProfile& currentProfile) {
 
 	std::ifstream loadButtonMapping(std::format("{}/mapping.txt", dirEntry));
 	if (loadButtonMapping.is_open()) {
-		int buttonMappingTemp[15]{};
+		int buttonMappingTemp[19]{};
 		for (int i = 0; i < ARRAYSIZE(currentProfile.buttonMapping); i++)
 			loadButtonMapping >> buttonMappingTemp[i];
 		for (int i = 0; i < ARRAYSIZE(currentProfile.buttonMapping); i++)


### PR DESCRIPTION
- Added possiblity to map PS Button, Touchpad Button and Mic Button
- Fixed parenthesis mistake for start and select press detection with mapping
- Fixed a bug where mapping 2 buttons to the same button and pressing them at the same time would work incorrectly
- Added Mic button visualisation in debugData
- Cleaned visualisation of buttons press in debugData
- Changed names of buttons in Mapping HMI to be more faithful to PCXSense behavior and names used in games : Playstation buttons are mapped on XBox buttons
- Fixed HMI button "Create new trigger Profile" to more accurate "Create new Game Profile"

Tested on DualSense but not on DS4